### PR TITLE
switch to standard-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "inherits": "^2.0.1",
     "minimist": "^1.1.1",
     "standard": "^4.5.4",
+    "standard-json": "^1.0.0",
     "text-table": "^0.2.0"
   },
   "homepage": "https://github.com/feross/snazzy",


### PR DESCRIPTION
Made [standard-json](https://github.com/Flet/standard-json) today from some of the `snazzy` guts in order to make [standard-tap](https://github.com/Flet/standard-tap)

This PR replaces said guts with `standard-json` instead.
