### PR TITLE
BREAKING: Remove built-in copy of `standard`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
 language: node_js
-sudo: true
 node_js:
-- '0.10'
-- '0.12'
-- 'iojs'
+- 'node'

--- a/README.md
+++ b/README.md
@@ -33,17 +33,18 @@ Pipe "compact" text into the `snazzy` command to get back pretty results:
 $ standard --verbose | snazzy
 ```
 
-Or, just run `snazzy` directly and it will run `standard` and give you pretty results:
+## note about version 7.0.0
 
-```bash
-$ snazzy
-```
+`standard` is no longer bundled with snazzy. You must install `standard` manually
+alongside `snazzy`.
 
-`snazzy` supports all command line flags that `standard` supports:
+Run `npm install standard --save-dev` to get a copy of `standard`, then run
+`standard | snazzy` where you previously used to ran `snazzy`.
 
-```bash
-$ snazzy --format --verbose test1.js test2.js
-```
+This method requires more steps but it's better since the user controls the exact
+version of `standard` that is used. And for users who were piping into `snazzy` all
+along, this means a quicker install since an extra copy of `standard` will not get
+installed.
 
 ## license
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,12 +1,7 @@
 #!/usr/bin/env node
 
 var CompactToStylishStream = require('../')
-var cp = require('child_process')
 var minimist = require('minimist')
-var path = require('path')
-
-var STANDARD_CMD = path.join(require.resolve('standard'), '../../.bin/standard')
-if (process.platform === 'win32') STANDARD_CMD += '.cmd'
 
 var argv = minimist(process.argv.slice(2), {
   boolean: [
@@ -14,33 +9,22 @@ var argv = minimist(process.argv.slice(2), {
   ]
 })
 
-var snazzy = new CompactToStylishStream()
-
-// Set the process exit code based on whether snazzy found errors.
-process.on('exit', function (code) {
-  if (code === 0 && snazzy.exitCode !== 0) {
-    process.exit(snazzy.exitCode)
-  }
-})
-process.stdout.on('error', function () {})
-
 if (!process.stdin.isTTY || argv._[0] === '-' || argv.stdin) {
-  process.stdin.pipe(snazzy).pipe(process.stdout)
-} else {
-  var args = process.argv.slice(2)
-  var standard = cp.spawn(STANDARD_CMD, args)
-  standard.stderr.pipe(process.stderr)
-  standard.stdout.pipe(snazzy).pipe(process.stdout)
+  var snazzy = new CompactToStylishStream()
 
-  // This only runs if snazzy finds no errors AND `standard` exited with a
-  // non-zero code. That means something weird happened, so set exit code to
-  // non-zero.
-  var standardCode
-  standard.on('exit', function (code) { standardCode = code })
+  // Set the process exit code based on whether snazzy found errors.
   process.on('exit', function (code) {
-    if (code === 0 && standardCode !== 0) {
-      console.error('Unexpected exit from the `standard` command')
-      process.exit(standardCode)
+    if (code === 0 && snazzy.exitCode !== 0) {
+      process.exit(snazzy.exitCode)
     }
   })
+
+  process.stdout.on('error', function () {})
+  process.stdin.pipe(snazzy).pipe(process.stdout)
+} else {
+  console.error(`
+snazzy: 'standard' is no longer bundled with 'snazzy'. Install standard
+snazzy: ('npm install standard') then run 'standard | snazzy' instead.
+  `)
+  process.exitCode = 1
 }

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -12,14 +12,13 @@ var argv = minimist(process.argv.slice(2), {
 if (!process.stdin.isTTY || argv._[0] === '-' || argv.stdin) {
   var snazzy = new CompactToStylishStream()
 
-  // Set the process exit code based on whether snazzy found errors.
+  // Set the process exit code based on whether snazzy found errors
   process.on('exit', function (code) {
     if (code === 0 && snazzy.exitCode !== 0) {
-      process.exit(snazzy.exitCode)
+      process.exitCode = snazzy.exitCode
     }
   })
 
-  process.stdout.on('error', function () {})
   process.stdin.pipe(snazzy).pipe(process.stdout)
 } else {
   console.error(`

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function CompactToStylishStream (opts) {
   }
   stream.Transform.call(this, opts)
 
+  this.exitCode = 0
   this._buffer = []
 }
 

--- a/package.json
+++ b/package.json
@@ -18,22 +18,24 @@
     "inherits": "^2.0.1",
     "minimist": "^1.1.1",
     "readable-stream": "^2.0.6",
-    "standard": "*",
     "standard-json": "^1.0.0",
     "text-table": "^0.2.0"
   },
+  "devDependencies": {
+    "standard": "*"
+  },
   "homepage": "https://github.com/feross/snazzy",
   "keywords": [
-    "stylish standard",
+    "pretty",
+    "pretty output",
+    "snazzy standard",
+    "standard",
+    "standard pretty",
+    "stylish",
     "stylish for standard",
     "stylish formatter",
-    "snazzy standard",
-    "stylish",
     "stylish reporter",
-    "standard",
-    "pretty output",
-    "pretty",
-    "standard pretty"
+    "stylish standard"
   ],
   "license": "MIT",
   "main": "index.js",
@@ -42,6 +44,6 @@
     "url": "git://github.com/feross/snazzy.git"
   },
   "scripts": {
-    "test": "./bin/cmd.js --verbose"
+    "test": "standard --verbose | ./bin/cmd.js"
   }
 }


### PR DESCRIPTION
`standard` is no longer bundled with snazzy. You must install `standard` manually alongside `snazzy`.

Run `npm install standard --save-dev` to get a copy of `standard`, then run `standard | snazzy` where you previously used to ran `snazzy`.

Though this takes more steps, it's better because it allows the user to control the exact version of `standard` that gets used. And for users who were piping into `snazzy` all along, this means a quicker install, since an extra copy of `standard` will not get installed.